### PR TITLE
{feature} build-angular: add bundleDependencies option to library builder

### DIFF
--- a/integration/__tests__/journey.spec.ts
+++ b/integration/__tests__/journey.spec.ts
@@ -61,7 +61,8 @@ async function exec(
 		stdout: stripAnsi(stdout.getContent().toString()).trim(),
 		stderr: stripAnsi(stderr.getContent().toString())
 			.trim()
-			.replace(/^.*✔/s, "✔"),
+			.replace(/^.*[✔√]/s, "✔")
+			.replace(/»/g, "›"),
 	};
 }
 

--- a/packages/build-angular/README.md
+++ b/packages/build-angular/README.md
@@ -50,6 +50,10 @@ Properties:
   Whether to keep the devDependencies in package.json, defaults to false
   Type: `boolean`
 
+- `bundleDependencies`
+  Whether to bundle dependencies in the output, defaults to false
+  Type: `boolean`
+
 - `inlineStyleLanguage`
   Language for inline styles in components, defaults to `css`
   Type: `string`

--- a/packages/build-angular/src/builders/library/config.js
+++ b/packages/build-angular/src/builders/library/config.js
@@ -7,6 +7,7 @@ const testConfiguration = t.isObject({
 
 	keepScripts: t.isOptional(t.isBoolean()),
 	keepDevDependencies: t.isOptional(t.isBoolean()),
+	bundleDependencies: t.isOptional(t.isBoolean()),
 
 	packager: t.isOptional(t.isString()),
 

--- a/packages/build-angular/src/builders/library/executor.js
+++ b/packages/build-angular/src/builders/library/executor.js
@@ -42,6 +42,7 @@ export async function executeBuild(
 
 		keepDevDependencies,
 		keepScripts,
+		bundleDependencies,
 
 		flags,
 	},
@@ -55,6 +56,7 @@ export async function executeBuild(
 
 	keepScripts ??= configuration.keepScripts;
 	keepDevDependencies ??= configuration.keepDevDependencies;
+	bundleDependencies ??= configuration.bundleDependencies;
 
 	packager ??= configuration.packager;
 	shouldRunPackage ??= !!packager;
@@ -174,6 +176,7 @@ export async function executeBuild(
 
 			keepDevDependencies,
 			keepScripts,
+			bundleDependencies,
 			outputFolder,
 			plugins: loadedPlugins,
 			inlineStyleLanguage,

--- a/packages/build-angular/src/builders/library/schema.d.ts
+++ b/packages/build-angular/src/builders/library/schema.d.ts
@@ -53,6 +53,11 @@ export interface Schema {
 	keepDevDependencies?: boolean;
 
 	/**
+	 * Whether to bundle dependencies in the output, defaults to `false`
+	 */
+	bundleDependencies?: boolean;
+
+	/**
 	 * Plugins to load
 	 */
 	plugins?: (string | [string, JsonObject])[];

--- a/packages/build-angular/src/builders/library/schema.json
+++ b/packages/build-angular/src/builders/library/schema.json
@@ -24,6 +24,10 @@
 			"type": "boolean",
 			"description": "Whether to keep the devDependencies in package.json, defaults to false"
 		},
+		"bundleDependencies": {
+			"type": "boolean",
+			"description": "Whether to bundle dependencies in the output, defaults to false"
+		},
 		"inlineStyleLanguage": {
 			"type": "string",
 			"description": "Language for inline styles in components, defaults to `css`"

--- a/packages/build-angular/src/compiler.js
+++ b/packages/build-angular/src/compiler.js
@@ -98,6 +98,10 @@ export {BuildFailureError, createCompileCache};
  *
  * Defaults to `false`.
  *
+ * @property {boolean} [bundleDependencies] Whether to bundle dependencies in the output
+ *
+ * Defaults to `false`.
+ *
  * @property {string} [inlineStyleLanguage] The language to use for inline styles
  *
  * The default value is `'css'`.
@@ -137,6 +141,7 @@ export async function build({
 	plugins: pluginFactories = [],
 	keepScripts = false,
 	keepDevDependencies = keepScripts,
+	bundleDependencies = false,
 	inlineStyleLanguage = "css",
 	flags: {
 		usePrivateApiAsImportIssueWorkaround = flags.usePrivateApiAsImportIssueWorkaround,
@@ -175,7 +180,7 @@ export async function build({
 			return {
 				packageName,
 				exportName,
-				mainFile,
+				mainFile: ensureUnixPath(mainFile),
 
 				esmFile: null,
 				fesmFile: join(fesmOutputFolder, `${getUnscopedName(packageName)}.js`),
@@ -215,6 +220,7 @@ export async function build({
 				logger,
 				keepScripts,
 				keepDevDependencies,
+				bundleDependencies,
 				inlineStyleLanguage,
 				flags: {enableApiExtractor, usePrivateApiAsImportIssueWorkaround},
 			},
@@ -277,6 +283,7 @@ export async function build({
 	await flattenCode(buildContext, {
 		target: `es${targetLanguageLevel}`,
 		outputFolder: fesmOutputFolder,
+		bundleDependencies,
 	});
 
 	performance.mark("code-flattened");

--- a/packages/build-angular/src/compiler/flatten/code.js
+++ b/packages/build-angular/src/compiler/flatten/code.js
@@ -11,6 +11,7 @@ import {BuildFailureError} from "../error.js";
  * @typedef {object} FlattenCodeInput
  * @property {string} outputFolder
  * @property {string} target
+ * @property {boolean} [bundleDependencies]
  */
 
 /**
@@ -46,7 +47,7 @@ function resolveOnlySelf(entryPoints) {
 					//                                         [A-Za-z][^:]                // A drive letter but then not a colon
 					//                                                      [^./\\A-Za-z]  // not a dot, slash or drive letter
 					filter:
-						/^(?:\.\.[^/\\]|\.[^./\\]|[A-Za-z]:[^\\]|[A-Za-z][^:]|[^./\\A-Za-z])/,
+						/^(?:\.\.[^/\\]|\.[^./\\]|[A-Za-z]:[^\\/]|[A-Za-z][^:]|[^./\\A-Za-z])/,
 				},
 				({path: specifier}) => {
 					const path = ownImports.get(specifier);
@@ -105,7 +106,9 @@ export async function flattenCode(context, input) {
 			target: [input.target],
 			format: "esm",
 			plugins: [
-				resolveOnlySelf(context.entryPoints),
+				...(input.bundleDependencies ?
+					[]
+				:	[resolveOnlySelf(context.entryPoints)]),
 				...context.plugins.map((plugin) => plugin.esbuildPlugin),
 			],
 			sourcemap: "linked",


### PR DESCRIPTION
This adds a new 'bundleDependencies' option to the library builder.
When enabled, it allows esbuild to bundle dependencies instead of marking them as external.
This is required for scenarios like running Karma tests with coverage, where dependencies need to be included in the bundle for the browser to resolve them correctly.